### PR TITLE
Fix for manual download links

### DIFF
--- a/src/mod-providers/curseforge/curseforge-mod-provider.ts
+++ b/src/mod-providers/curseforge/curseforge-mod-provider.ts
@@ -30,8 +30,7 @@ export class CurseForgeModProvider implements ModProvider<CurseForgeModIdentifie
 
             if (!downloadUrl) {
                 const project = await this.getProjectMetadata(mod.projectID);
-                const url = `https://www.curseforge.com/minecraft/mc-mods/${project.slug}/${mod.fileID}`;
-                throw new NoDownloadException(fileName, url);
+                throw new NoDownloadException(fileName, project.links.websiteUrl);
             }
 
             return {


### PR DESCRIPTION
This PR fixes links for texture packs and data packs that need manual download (no more 404 links 🤞)