### PR TITLE
Add a note to the README about CurseForge vs CurseForge for Studios

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ If this is your first time running the script you have to perform some additiona
 > [!IMPORTANT]
 > The above step has to be repeated after pulling a new version of the script.
 2. Copy the file `settings.example.json` and rename it to `settings.json`.
-3. Acquire an API key from [the CurseForge website](https://console.curseforge.com/?#/api-keys) after logging in.
+3. Acquire an API key from [the CurseForge for Studios website](https://console.curseforge.com/?#/api-keys) after logging in.
+
+> [!IMPORTANT]
+> The API key you need is **not** one of the "API tokens" you can generate from your profile on the main CurseForge website; you need to use the link above to go to CurseForge for Studios and copy the key there into your settings.
 
 > [!IMPORTANT]
 > The above step is still required, even if you don't intend on downloading from CurseForge. Other providers (modpacks.ch) might delegate the download to CurseForge behind the scenes.


### PR DESCRIPTION
I just found your downloader and, while setting it up, made the rookie mistake of *skimming* the instructions instead of **reading** them. As a result, I ended up trying to use a CurseForge API token instead of a CurseForge for Studios API key which unsurprisingly doesn't work at all. 😅

This change just adds another notice to the API token step in the instructions clarifying that you really do need to get a key from CurseForge *for Studios*, not the regular CurseForge site. Hopefully, that will reduce the chances of someone making the same mistake in the future.