### PR TITLE
Point curseforge links to specific files

### DIFF
--- a/src/mod-providers/curseforge/curseforge-mod-provider.ts
+++ b/src/mod-providers/curseforge/curseforge-mod-provider.ts
@@ -30,7 +30,7 @@ export class CurseForgeModProvider implements ModProvider<CurseForgeModIdentifie
 
             if (!downloadUrl) {
                 const project = await this.getProjectMetadata(mod.projectID);
-                throw new NoDownloadException(fileName, project.links.websiteUrl);
+                throw new NoDownloadException(fileName, project.links.websiteUrl + "/files/" + mod.fileID);
             }
 
             return {


### PR DESCRIPTION
Currently when mods can't be downloaded a link to the mod homepage on curseforge is provided.
With this patch the links provided are specific for the correct mod version specified by the modpack's manifest.