### PR TITLE
Added a way to provide manifest.json from a different location

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ The `settings.json` file provides several options to customize your experience. 
         "outputDirectory": "mods"
     },
     "curseforge": {
-        "apiKey": // no default
+        "apiKey": // no default,
+        "manifestFile": "manifest.json"
     }
 }
 ```
@@ -129,6 +130,7 @@ The `settings.json` file provides several options to customize your experience. 
 
 ### CurseForge
 - `apiKey` - CurseForge requires users of their api to provide an api key. You can get yours for free on [their website](https://console.curseforge.com/?#/api-keys) after logging in.
+- `manifestFile` - The manifest file path of the CurseForge modpack's manifest.
 
 > [!CAUTION]
 > Your API key is sensative information, you shouldn't post it online.
@@ -147,6 +149,7 @@ Additionally the following optional options can be specified:
 - `--output-directory <path>` or `-o <path>` - The directory to store the downloaded files in
 - `--log-file <path>` - The file to log to
 - `--log-level <level>` - The lowest level of importance to log. Valid values are: be `debug`, `info`, `warn`, and `error`
+- `--manifest-file` - The file path of the modpack's manifest (only when using curseforge provider)
 
 > [!NOTE]
 > If you are using any of the options start with '-' or '--', an additional '--' following 'npm start' is required to indicate the start of the arguments to the actual script, this can be seen in the examples below.

--- a/src/app.ts
+++ b/src/app.ts
@@ -65,7 +65,7 @@ if (!await isDirectoryEmpty(config.downloads.outputDirectory)) {
 
 const modpackId = {
     "modpacks.ch": config["modpacks.ch"].modpack,
-    "curseforge": "manifest.json",
+    "curseforge": config["curseforge"].manifest,
     "local": "debug"
 }[provider];
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -65,7 +65,7 @@ if (!await isDirectoryEmpty(config.downloads.outputDirectory)) {
 
 const modpackId = {
     "modpacks.ch": config["modpacks.ch"].modpack,
-    "curseforge": config["curseforge"].manifest,
+    "curseforge": config.curseforge.manifestFile,
     "local": "debug"
 }[provider];
 

--- a/src/configuration/arguments-configuration-source.ts
+++ b/src/configuration/arguments-configuration-source.ts
@@ -73,7 +73,7 @@ export function getArgumentConfiguration(provider: ModProviderName): PartialConf
     const bindings: { [Key in keyof Arguments]: PartialConfiguration } = {
         "modpack-id": { "modpacks.ch": { modpack: { id: args["modpack-id"] } } },
         "modpack-version": { "modpacks.ch": { modpack: { version: args["modpack-version"] } } },
-        "manifest-file": { curseforge: { manifestFile: args["manifest-file"] } },
+        "manifest-file": { curseforge: { manifestFile: args["manifest-file"] ?? "manifest.json" } }, // Couldn't find a way to set default in a nicer way
         "yes": { confirmAll: args["yes"] },
         "concurrency": { downloads: { concurrency: args["concurrency"] } },
         "output-directory": { downloads: { outputDirectory: args["output-directory"] } },

--- a/src/configuration/arguments-configuration-source.ts
+++ b/src/configuration/arguments-configuration-source.ts
@@ -73,7 +73,7 @@ export function getArgumentConfiguration(provider: ModProviderName): PartialConf
     const bindings: { [Key in keyof Arguments]: PartialConfiguration } = {
         "modpack-id": { "modpacks.ch": { modpack: { id: args["modpack-id"] } } },
         "modpack-version": { "modpacks.ch": { modpack: { version: args["modpack-version"] } } },
-        "manifest-file": { "curseforge": { manifest: args["manifest-file"] } },
+        "manifest-file": { curseforge: { manifestFile: args["manifest-file"] } },
         "yes": { confirmAll: args["yes"] },
         "concurrency": { downloads: { concurrency: args["concurrency"] } },
         "output-directory": { downloads: { outputDirectory: args["output-directory"] } },

--- a/src/configuration/arguments-configuration-source.ts
+++ b/src/configuration/arguments-configuration-source.ts
@@ -7,6 +7,7 @@ import * as _ from "lodash-es";
 interface Arguments {
     "modpack-id"?: number,
     "modpack-version"?: number,
+    "manifest-file"?: string,
     "concurrency"?: number,
     "output-directory"?: string,
     "log-file": string,
@@ -54,6 +55,12 @@ export function getArgumentConfiguration(provider: ModProviderName): PartialConf
         })
     }
 
+    if (provider == "curseforge") {
+        _.defaults(argumentConfig, {
+            "manifest-file": { type: String, optional: true, description: "The location of the manifest.json file" },
+        })
+    }
+
     const args = parse<Arguments>(
         argumentConfig as ArgumentConfig<Arguments>,
         {
@@ -66,6 +73,7 @@ export function getArgumentConfiguration(provider: ModProviderName): PartialConf
     const bindings: { [Key in keyof Arguments]: PartialConfiguration } = {
         "modpack-id": { "modpacks.ch": { modpack: { id: args["modpack-id"] } } },
         "modpack-version": { "modpacks.ch": { modpack: { version: args["modpack-version"] } } },
+        "manifest-file": { "curseforge": { manifest: args["manifest-file"] } },
         "yes": { confirmAll: args["yes"] },
         "concurrency": { downloads: { concurrency: args["concurrency"] } },
         "output-directory": { downloads: { outputDirectory: args["output-directory"] } },

--- a/src/configuration/arguments-configuration-source.ts
+++ b/src/configuration/arguments-configuration-source.ts
@@ -73,7 +73,7 @@ export function getArgumentConfiguration(provider: ModProviderName): PartialConf
     const bindings: { [Key in keyof Arguments]: PartialConfiguration } = {
         "modpack-id": { "modpacks.ch": { modpack: { id: args["modpack-id"] } } },
         "modpack-version": { "modpacks.ch": { modpack: { version: args["modpack-version"] } } },
-        "manifest-file": { curseforge: { manifestFile: args["manifest-file"] ?? "manifest.json" } }, // Couldn't find a way to set default in a nicer way
+        "manifest-file": { curseforge: { manifestFile: args["manifest-file"] } },
         "yes": { confirmAll: args["yes"] },
         "concurrency": { downloads: { concurrency: args["concurrency"] } },
         "output-directory": { downloads: { outputDirectory: args["output-directory"] } },

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -43,6 +43,12 @@ export async function loadConfiguration(provider: ModProviderName): Promise<Conf
         config["modpacks.ch"].modpack = modpack as ModpacksChModpackIdentifier;
     }
 
+    if (provider == "curseforge") {
+      const curseforgeConfig: Partial<CurseForgeModProviderConfiguration> = config["curseforge"] ?? {};
+      curseforgeConfig.manifest ??= "manifest.json";
+      config["curseforge"] = curseforgeConfig as CurseForgeModProviderConfiguration;
+    }
+
     return config as Configuration;
 }
 

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -44,9 +44,9 @@ export async function loadConfiguration(provider: ModProviderName): Promise<Conf
     }
 
     if (provider == "curseforge") {
-      const curseforgeConfig: Partial<CurseForgeModProviderConfiguration> = config["curseforge"] ?? {};
-      curseforgeConfig.manifest ??= "manifest.json";
-      config["curseforge"] = curseforgeConfig as CurseForgeModProviderConfiguration;
+      const curseforgeConfig: Partial<CurseForgeModProviderConfiguration> = config.curseforge ?? {};
+      curseforgeConfig.manifestFile ??= "manifest.json";
+      config.curseforge = curseforgeConfig as CurseForgeModProviderConfiguration;
     }
 
     return config as Configuration;

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -43,12 +43,6 @@ export async function loadConfiguration(provider: ModProviderName): Promise<Conf
         config["modpacks.ch"].modpack = modpack as ModpacksChModpackIdentifier;
     }
 
-    if (provider == "curseforge") {
-      const curseforgeConfig: Partial<CurseForgeModProviderConfiguration> = config.curseforge ?? {};
-      curseforgeConfig.manifestFile ??= "manifest.json";
-      config.curseforge = curseforgeConfig as CurseForgeModProviderConfiguration;
-    }
-
     return config as Configuration;
 }
 

--- a/src/configuration/default-configuration-source.ts
+++ b/src/configuration/default-configuration-source.ts
@@ -11,6 +11,9 @@ export function getDefaultConfiguration(): PartialConfiguration {
             outputDirectory: "mods",
         },
         ["modpacks.ch"]: {},
+        curseforge: {
+            manifestFile: "manifest.json"
+        },
         confirmAll: false
     };
 }

--- a/src/mod-providers/curseforge/curseforge-types.ts
+++ b/src/mod-providers/curseforge/curseforge-types.ts
@@ -1,5 +1,6 @@
 export interface CurseForgeModProviderConfiguration {
-    apiKey: string
+    apiKey: string,
+    manifest: string
 }
 
 export interface CurseForgeModIdentifier {

--- a/src/mod-providers/curseforge/curseforge-types.ts
+++ b/src/mod-providers/curseforge/curseforge-types.ts
@@ -1,6 +1,6 @@
 export interface CurseForgeModProviderConfiguration {
     apiKey: string,
-    manifest: string
+    manifestFile: string
 }
 
 export interface CurseForgeModIdentifier {


### PR DESCRIPTION
This PR should solve issue #13.
It adds a way to provide the manifest.json path as an argument or as a settings.json parameter.